### PR TITLE
Support cmake 4.0

### DIFF
--- a/ucm.cmake
+++ b/ucm.cmake
@@ -10,7 +10,7 @@
 # The documentation can be found at the library's page:
 # https://github.com/onqtam/ucm
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 include(CMakeParseArguments)
 


### PR DESCRIPTION
 - cmake 4.0 demands minimum version of 3.5 (https://github.com/rordenlab/dcm2niix/issues/925)